### PR TITLE
Cw orders get

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3102,7 +3102,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3120,11 +3121,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3137,15 +3140,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3248,7 +3254,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3258,6 +3265,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3270,17 +3278,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3297,6 +3308,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3369,7 +3381,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3379,6 +3392,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3454,7 +3468,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3484,6 +3499,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3501,6 +3517,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3539,11 +3556,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -7734,7 +7753,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -7758,6 +7778,7 @@
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7770,7 +7791,8 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -7779,7 +7801,8 @@
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -7882,7 +7905,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -7892,6 +7916,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -7904,17 +7929,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -7931,6 +7959,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -8003,7 +8032,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -8013,6 +8043,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -8088,7 +8119,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -8118,6 +8150,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -8135,6 +8168,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -8173,11 +8207,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         }

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -12,6 +12,7 @@ import PartnersAdmin from '../components/pages/PartnersAdmin/PartnersAdmin';
 import Products from '../components/pages/Products/Products';
 import ItemDetail from '../components/pages/ItemDetail/ItemDetail';
 import Profile from '../components/pages/Profile/Profile';
+import Orders from '../components/pages/Orders/Orders';
 import Partners from '../components/pages/Partners/Partners';
 import ShoppingCart from '../components/pages/ShoppingCart/ShoppingCart';
 import cartRequests from '../helpers/data/cartRequests';
@@ -123,6 +124,11 @@ class App extends React.Component {
                   <PrivateRoute
                     path="/profile"
                     component={props => <Profile userObject={userObject} updateUser={this.getCurrentUser} {...props} />}
+                    authed={authed}
+                  />
+                  <PrivateRoute
+                    path="/orders"
+                    component={props => <Orders userObject={userObject} updateUser={this.getCurrentUser} {...props} />}
                     authed={authed}
                   />
                   <PrivateRoute

--- a/src/components/AppNavbar/AppNavbar.js
+++ b/src/components/AppNavbar/AppNavbar.js
@@ -97,7 +97,7 @@ class AppNavbar extends React.Component {
                   <i className="navIcon lnr lnr-user" />
                   Profile
                 </DropdownItem>
-                <DropdownItem className="profBtn nav-link" to="/orders">
+                <DropdownItem tag={RRNavLink} className="profBtn nav-link" to="/orders">
                   <i className="navIcon lnr lnr-layers" />
                   Orders
                 </DropdownItem>

--- a/src/components/OrderItems/OrderItems.js
+++ b/src/components/OrderItems/OrderItems.js
@@ -10,6 +10,10 @@ class OrderItems extends React.Component
             <div className="order-item-div">
                 <h1>Hello again</h1>
                 <h3>{order.firstName}</h3>
+                {/* <h4>{printOrderItem}</h4> */}
+                {/* <h3>{orderItems.name}</h3>
+                <h4>{orderItems.quantity}</h4>
+                <h5>{orderItems.unitPrice}</h5> */}
             </div>
         );
     }

--- a/src/components/OrderItems/OrderItems.js
+++ b/src/components/OrderItems/OrderItems.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import './OrderItems.js';
+
+class OrderItems extends React.Component
+{
+    render() {
+        const { order } = this.props;
+
+        return (
+            <div className="Please">
+                <h1>Hello again</h1>
+            </div>
+        );
+    }
+}
+
+export default OrderItems;

--- a/src/components/OrderItems/OrderItems.js
+++ b/src/components/OrderItems/OrderItems.js
@@ -1,5 +1,7 @@
 import React from 'react';
+import { Button } from 'reactstrap';
 import './OrderItems.scss';
+import utility from '../../helpers/utils/utility';
 
 class OrderItems extends React.Component
 {
@@ -8,14 +10,34 @@ class OrderItems extends React.Component
 
         return (
             <div className="orderCard card2 col-6">
-                <h1>Details for Order #{order.id}</h1>
-                <h3>{order.firstName} {order.lastName}</h3>
-                {order.orderItems.map((orderitem, i) => (
-                    //<div>
+                <h2>Details for Order #{order.id}</h2>
+                <h3>Ordered on {utility.dateFormat(order.purchaseDate)}</h3>
+
+                <div className="billing-ordersummary">
+                
+                <div className="billing-address">
+                <h4>Billing Address</h4>
+                <h6>{order.firstName} {order.lastName}</h6>
+                <h6>{order.street1}</h6>
+                <h6>{order.city}, {order.state} {order.zipCode}</h6>
+                <h5 className="payment-method">Payment Method: VISA</h5>
+                </div>
+            
+                <div className="order-summary">
+                <h4>Order Summary</h4>
+                <h6>Item(s) Subtotal: ${order.subtotal}</h6>
+                <h6>Shipping & Handling: $0.00</h6>
+                <h6>Sales Tax: ${order.tax}</h6>
+                <h6>Grand Total: ${order.total}</h6>
+                <Button color="primary">More Details</Button>
+                </div>
+
+                </div>
+                {/* <h5>Payment Method: VISA</h5> */}
+
+                {/* {order.orderItems.map((orderitem, i) => (
                     <h3 key={i}>{orderitem.name}</h3>
-                    //<h3>{orderitem.quantity}</h3>
-                    // </div>
-                ))}
+                ))} */}
             </div>
         );
     }

--- a/src/components/OrderItems/OrderItems.js
+++ b/src/components/OrderItems/OrderItems.js
@@ -10,7 +10,13 @@ class OrderItems extends React.Component
             <div className="order-item-div">
                 <h1>Hello again</h1>
                 <h3>{order.firstName}</h3>
-                {/* <h4>{printOrderItem}</h4> */}
+                {order.orderItems.map((orderitem, i) => (
+                    <div>
+                    <h3 key={i}>{orderitem.name}</h3>
+                    <h3>{orderitem.quantity}</h3>
+                    </div>
+                ))}
+                {/* <h3>{orderitem.name}</h3> */}
                 {/* <h3>{orderItems.name}</h3>
                 <h4>{orderItems.quantity}</h4>
                 <h5>{orderItems.unitPrice}</h5> */}

--- a/src/components/OrderItems/OrderItems.js
+++ b/src/components/OrderItems/OrderItems.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import './OrderItems.js';
+import './OrderItems.scss';
 
 class OrderItems extends React.Component
 {
@@ -7,8 +7,9 @@ class OrderItems extends React.Component
         const { order } = this.props;
 
         return (
-            <div className="Please">
+            <div className="order-item-div">
                 <h1>Hello again</h1>
+                <h3>{order.name}</h3>
             </div>
         );
     }

--- a/src/components/OrderItems/OrderItems.js
+++ b/src/components/OrderItems/OrderItems.js
@@ -7,19 +7,15 @@ class OrderItems extends React.Component
         const { order } = this.props;
 
         return (
-            <div className="order-item-div">
-                <h1>Hello again</h1>
-                <h3>{order.firstName}</h3>
+            <div className="orderCard card2 col-6">
+                <h1>Details for Order #{order.id}</h1>
+                <h3>{order.firstName} {order.lastName}</h3>
                 {order.orderItems.map((orderitem, i) => (
-                    <div>
+                    //<div>
                     <h3 key={i}>{orderitem.name}</h3>
-                    <h3>{orderitem.quantity}</h3>
-                    </div>
+                    //<h3>{orderitem.quantity}</h3>
+                    // </div>
                 ))}
-                {/* <h3>{orderitem.name}</h3> */}
-                {/* <h3>{orderItems.name}</h3>
-                <h4>{orderItems.quantity}</h4>
-                <h5>{orderItems.unitPrice}</h5> */}
             </div>
         );
     }

--- a/src/components/OrderItems/OrderItems.js
+++ b/src/components/OrderItems/OrderItems.js
@@ -9,7 +9,7 @@ class OrderItems extends React.Component
         return (
             <div className="order-item-div">
                 <h1>Hello again</h1>
-                <h3>{order.name}</h3>
+                <h3>{order.firstName}</h3>
             </div>
         );
     }

--- a/src/components/OrderItems/OrderItems.js
+++ b/src/components/OrderItems/OrderItems.js
@@ -10,7 +10,7 @@ class OrderItems extends React.Component
 
         return (
             <div className="orderCard card2 col-6">
-                <h2>Details for Order #{order.id}</h2>
+                <h2 className="order-details-header">Details for Order #{order.id}</h2>
                 <h3>Ordered on {utility.dateFormat(order.purchaseDate)}</h3>
 
                 <div className="billing-ordersummary">
@@ -28,16 +28,11 @@ class OrderItems extends React.Component
                 <h6>Item(s) Subtotal: ${order.subtotal}</h6>
                 <h6>Shipping & Handling: $0.00</h6>
                 <h6>Sales Tax: ${order.tax}</h6>
-                <h6>Grand Total: ${order.total}</h6>
+                <h6 className="grand-total">Grand Total: ${order.total}</h6>
                 <Button color="primary">More Details</Button>
                 </div>
 
                 </div>
-                {/* <h5>Payment Method: VISA</h5> */}
-
-                {/* {order.orderItems.map((orderitem, i) => (
-                    <h3 key={i}>{orderitem.name}</h3>
-                ))} */}
             </div>
         );
     }

--- a/src/components/OrderItems/OrderItems.scss
+++ b/src/components/OrderItems/OrderItems.scss
@@ -22,3 +22,7 @@ h4 {
     margin-top: 30px;
     font-weight: bold;
 }
+
+.grand-total, .order-details-header {
+    font-weight: bold;
+}

--- a/src/components/OrderItems/OrderItems.scss
+++ b/src/components/OrderItems/OrderItems.scss
@@ -5,3 +5,20 @@
     padding: 1%;
     background-color:  rgba(168, 202, 241, 0.75);
 }
+
+.billing-address {
+    float: left;
+}
+
+.order-summary {
+    float:right;
+}
+
+h4 {
+    font-weight: bold;
+}
+
+.payment-method {
+    margin-top: 30px;
+    font-weight: bold;
+}

--- a/src/components/OrderItems/OrderItems.scss
+++ b/src/components/OrderItems/OrderItems.scss
@@ -1,0 +1,7 @@
+.orderCard {
+    border: 2px solid;
+    border-radius: 5px;
+    margin: 1%;
+    padding: 1%;
+    background-color:  rgba(168, 202, 241, 0.75);
+}

--- a/src/components/pages/Orders/Orders.js
+++ b/src/components/pages/Orders/Orders.js
@@ -12,7 +12,10 @@ class Orders extends React.Component {
       const userid = this.props.userObject.id;
       orderRequests.getOrderById(userid)
       .then((result) => {
-          this.setState({ orders: result });
+          const sortedArray = [...result].sort(function (a, b) {
+              return b.id - a.id;
+          });
+          this.setState({ orders: sortedArray });
       });
   }
 

--- a/src/components/pages/Orders/Orders.js
+++ b/src/components/pages/Orders/Orders.js
@@ -24,12 +24,13 @@ class Orders extends React.Component {
   render() {
     const { orders } = this.state;
     
-    const printOrder = orders.map(order => {
-        <OrderItems
-        key={order.id}
-        order={order}
-        />
-    });
+     const printOrder = orders.map(order => (
+
+         <OrderItems
+         key={order.id}
+         order={order}
+         />
+   ));
 
       return (
         <div className="Order">

--- a/src/components/pages/Orders/Orders.js
+++ b/src/components/pages/Orders/Orders.js
@@ -12,7 +12,6 @@ class Orders extends React.Component {
       const userid = this.props.userObject.id;
       orderRequests.getOrderById(userid)
       .then((result) => {
-        console.log(result);
           this.setState({ orders: result });
       });
   }
@@ -24,19 +23,18 @@ class Orders extends React.Component {
   render() {
     const { orders } = this.state;
 
-     const printOrder = orders.map(order => (
+     const printOrders = orders.map(order => (
       
          <OrderItems
          key={order.id}
          order={order}
-         // orderItems={order.orderItems[0]}
          />
    ));
 
       return (
-        <div className="Order">
-            <h1>Hello</h1>
-            <h3>{printOrder}</h3>
+        <div className="orders-container">
+            <h1 className="orders-page-title">Your Orders</h1>
+            <h3 className="row justify-content-center">{printOrders}</h3>
         </div>
       );
     }

--- a/src/components/pages/Orders/Orders.js
+++ b/src/components/pages/Orders/Orders.js
@@ -4,6 +4,8 @@ import OrderItems from '../../OrderItems/OrderItems';
 import './Orders.scss';
 
 class Orders extends React.Component {
+    orderseMounted = false;
+
    state = { 
     orders: [],
    };
@@ -20,7 +22,14 @@ class Orders extends React.Component {
   }
 
   componentDidMount() {
+    this.orderseMounted = !!this.props.userObject.id;
+    if (this.orderseMounted) {
       this.getOrderById();
+    }
+  }
+
+  componentWillUnmount() {
+    this.orderseMounted = false;
   }
 
   render() {

--- a/src/components/pages/Orders/Orders.js
+++ b/src/components/pages/Orders/Orders.js
@@ -23,9 +23,9 @@ class Orders extends React.Component {
 
   render() {
     const { orders } = this.state;
-    
-     const printOrder = orders.map(order => (
 
+     const printOrder = orders.map(order => (
+      
          <OrderItems
          key={order.id}
          order={order}

--- a/src/components/pages/Orders/Orders.js
+++ b/src/components/pages/Orders/Orders.js
@@ -29,6 +29,7 @@ class Orders extends React.Component {
          <OrderItems
          key={order.id}
          order={order}
+         // orderItems={order.orderItems[0]}
          />
    ));
 

--- a/src/components/pages/Orders/Orders.js
+++ b/src/components/pages/Orders/Orders.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import orderRequests from '../../../helpers/data/orderRequests';
+import OrderItems from '../../OrderItems/OrderItems';
+import './Orders.scss';
+
+class Orders extends React.Component {
+   state = { 
+    orders: [],
+   };
+   
+  getOrderById() {
+      const userid = this.props.userObject.id;
+      orderRequests.getOrderById(userid)
+      .then((result) => {
+        console.log(result);
+          this.setState({ orders: result });
+      });
+  }
+
+  componentDidMount() {
+      this.getOrderById();
+  }
+
+  render() {
+    const { orders } = this.state;
+    
+    const printOrder = orders.map(order => {
+        <OrderItems
+        key={order.id}
+        order={order}
+        />
+    });
+
+      return (
+        <div className="Order">
+            <h1>Hello</h1>
+            <h3>{printOrder}</h3>
+        </div>
+      );
+    }
+   
+}
+
+export default Orders;

--- a/src/components/pages/Orders/Orders.scss
+++ b/src/components/pages/Orders/Orders.scss
@@ -1,3 +1,7 @@
-.Order {
+.orders-container {
     margin-top: 10%;
+}
+
+.orders-page-title {
+    text-align: center;
 }

--- a/src/components/pages/Orders/Orders.scss
+++ b/src/components/pages/Orders/Orders.scss
@@ -1,0 +1,3 @@
+.Order {
+    margin-top: 10%;
+}

--- a/src/helpers/data/orderRequests.js
+++ b/src/helpers/data/orderRequests.js
@@ -12,4 +12,26 @@ const createOrder = newOrder => new Promise((resolve, reject) => {
         .catch(error => reject(error));
 });
 
-export default { createOrder };
+const getAllOrders = () => new Promise((resolve, reject) => {
+    axios
+        .get(`${ordersApiBaseUrl}/api/orders`)
+        .then((result) => {
+            resolve(result.data);
+        })
+        .catch(error => reject(error));
+});
+
+const getOrderById = orderId => new Promise((resolve, reject) => {
+    axios
+    .get(`${ordersApiBaseUrl}/api/orders/${orderId}`)
+    .then((result) => {
+        resolve(result.data);
+    })
+    .catch(error => reject(error));
+});
+
+export default { 
+    createOrder, 
+    getAllOrders, 
+    getOrderById, 
+};

--- a/src/helpers/data/partnerRequests.js
+++ b/src/helpers/data/partnerRequests.js
@@ -39,8 +39,6 @@ const deletePartner = partnerId => new Promise((resolve, reject) => {
     .catch(error => reject(error));
 });
 
-// const deletePartner = partnerId => axios.delete(`${partnersApiBaseUrl}/api/partners/${partnerId}`);
-
 const createPartner = newPartner => new Promise((resolve, reject) => {
   axios
     .post(`${partnersApiBaseUrl}/api/partners/`, newPartner)


### PR DESCRIPTION
- Must pull down `cw-orders-GET` on back-end to run branch
- Go to your profile image and click `Orders` from the dropdown menu 
- Showing orders from most recent to first
- `Payment Method` is temporarily hard-coded and can be permanently removed if wanted
- The `More Details` button will be on the next branch enabling a full-page order view with the products listed similar to the `Store` page
